### PR TITLE
feat: support updating/extending a model as well as a machine

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -136,10 +136,11 @@ jobs:
           cache: npm
 
       - name: Install 🔧
-        run: npm i
+        run: npm ci
+
       - name: Create Canary Release ✨
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        run: npx auto shipit --dry-run
+        run: npx auto shipit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # xstate-test-cypress
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Utilities for adapting @xstate/test to work more easily with cypress 7+
@@ -62,6 +64,22 @@ context('example tests', () => {
     cy.visit('/');
     return { someCounter: 1 };
   });
+  checkCoverage(testModel);
+});
+
+context('updated tests', () => {
+  simpleExecutePlan(
+    testModel
+      .update(
+        { other: () => cy.log('new state check') },
+        { SIMPLE: () => cy.log('new event execution') }
+      )
+      .getSimplePathPlans(),
+    () => {
+      cy.visit('/');
+      return { someCounter: 1 };
+    }
+  );
   checkCoverage(testModel);
 });
 ```

--- a/cypress/components/Component.cypress.tsx
+++ b/cypress/components/Component.cypress.tsx
@@ -74,3 +74,26 @@ context('mount in machine step', () => {
   simpleExecutePlan(propsTestModel.getSimplePathPlans());
   checkCoverage(propsTestModel);
 });
+
+context('update model', () => {
+  simpleExecutePlan(
+    propsTestModel
+      .update(
+        {
+          init: () => cy.get('button').should('not.exist'),
+          sad: () => cy.get('button').should('have.text', 'modified sad'),
+          happy: () => cy.get('button').should('have.text', 'modified happy')
+        },
+        {
+          INIT: () => {
+            mount(
+              <Component happyLabel="modified happy" sadLabel="modified sad" />
+            );
+          },
+          TOGGLE: () => cy.get('button').click()
+        }
+      )
+      .getSimplePathPlans()
+  );
+  checkCoverage(propsTestModel);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,14 +26,14 @@
         "@xstate/test": "0.5.0",
         "auditjs": "4.0.33",
         "auto": "10.32.3",
-        "cypress": "9.1.1",
+        "cypress": "9.5.0",
         "husky": "7.0.4",
         "live-server": "1.2.1",
         "prettier": "2.5.1",
         "start-server-and-test": "1.14.0",
         "todomvc-app-css": "2.4.1",
         "todomvc-common": "1.0.5",
-        "xstate": "4.26.1"
+        "xstate": "4.30.1"
       },
       "peerDependencies": {
         "@xstate/test": ">=0.4 <0.6",
@@ -4195,9 +4195,9 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/sinonjs__fake-timers": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
-      "integrity": "sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
       "dev": true
     },
     "node_modules/@types/sizzle": {
@@ -7333,19 +7333,18 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
-      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "dependencies": {
-        "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
       "engines": {
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "colors": "^1.1.2"
+        "colors": "1.4.0"
       }
     },
     "node_modules/cli-truncate": {
@@ -9333,25 +9332,26 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.1.1.tgz",
-      "integrity": "sha512-yWcYD8SEQ8F3okFbRPqSDj5V0xhrZBT5QRIH+P1J2vYvtEmZ4KGciHE7LCcZZLILOrs7pg4WNCqkj/XRvReQlQ==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.0.tgz",
+      "integrity": "sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
-        "bluebird": "3.7.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.0",
+        "cli-table3": "~0.6.1",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -9375,10 +9375,10 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "bin": {
@@ -9393,6 +9393,30 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
       "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==",
       "dev": true
+    },
+    "node_modules/cypress/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/cypress/node_modules/execa": {
       "version": "4.1.0",
@@ -34397,9 +34421,9 @@
       "dev": true
     },
     "node_modules/xstate": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.26.1.tgz",
-      "integrity": "sha512-JLofAEnN26l/1vbODgsDa+Phqa61PwDlxWu8+2pK+YbXf+y9pQSDLRvcYH2H1kkeUBA5fGp+xFL/zfE8jNMw4g==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.30.1.tgz",
+      "integrity": "sha512-vNOk8iRfhtbl9/RVF6HJWbL+YfsfGLiee1tGm6cuDcPrSStsRvfAhLVxSPoePx5XBlCSYOXaweLStmrpk2rvhA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -37689,9 +37713,9 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
-      "integrity": "sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
       "dev": true
     },
     "@types/sizzle": {
@@ -40180,13 +40204,12 @@
       "dev": true
     },
     "cli-table3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
-      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
+        "colors": "1.4.0",
         "string-width": "^4.2.0"
       }
     },
@@ -41806,24 +41829,25 @@
       "dev": true
     },
     "cypress": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.1.1.tgz",
-      "integrity": "sha512-yWcYD8SEQ8F3okFbRPqSDj5V0xhrZBT5QRIH+P1J2vYvtEmZ4KGciHE7LCcZZLILOrs7pg4WNCqkj/XRvReQlQ==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.0.tgz",
+      "integrity": "sha512-rC5QPolKsVjJ8QJZ7IeZ6HlKM4gswBGZc0XvoAJNL8urQCSL8zTX0A/ai/h35WfF47NQ0iSZnwIXBlHX3MOUIQ==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
-        "bluebird": "3.7.2",
+        "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.0",
+        "cli-table3": "~0.6.1",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -41847,10 +41871,10 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
@@ -41859,6 +41883,16 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
           "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==",
           "dev": true
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
         },
         "execa": {
           "version": "4.1.0",
@@ -61707,9 +61741,9 @@
       "dev": true
     },
     "xstate": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.26.1.tgz",
-      "integrity": "sha512-JLofAEnN26l/1vbODgsDa+Phqa61PwDlxWu8+2pK+YbXf+y9pQSDLRvcYH2H1kkeUBA5fGp+xFL/zfE8jNMw4g==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.30.1.tgz",
+      "integrity": "sha512-vNOk8iRfhtbl9/RVF6HJWbL+YfsfGLiee1tGm6cuDcPrSStsRvfAhLVxSPoePx5XBlCSYOXaweLStmrpk2rvhA==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -68,13 +68,13 @@
     "@xstate/test": "0.5.0",
     "auditjs": "4.0.33",
     "auto": "10.32.3",
-    "cypress": "9.1.1",
+    "cypress": "9.5.0",
     "husky": "7.0.4",
     "live-server": "1.2.1",
     "prettier": "2.5.1",
     "start-server-and-test": "1.14.0",
     "todomvc-app-css": "2.4.1",
     "todomvc-common": "1.0.5",
-    "xstate": "4.26.1"
+    "xstate": "4.30.1"
   }
 }

--- a/src/createCypressModel.ts
+++ b/src/createCypressModel.ts
@@ -6,7 +6,8 @@ import {
   CypressTestEventConfig,
   CypressTestEventsConfig,
   EventCase,
-  UpdatableCypressMachine
+  UpdatableCypressMachine,
+  UpdateableCypressModel
 } from './types';
 
 export function createCypressModel<
@@ -22,7 +23,7 @@ export function createCypressModel<
 >(
   machine: TMachine,
   eventMap: CypressTestEventsConfig<TTestContext>
-): TestModel<TTestContext, any> {
+): UpdateableCypressModel<TTestContext> {
   const cypressEventMap: TestModel<TTestContext, any>['options']['events'] = {};
   machine.events.forEach((eventKey) => {
     const eventLog = () => cy.log(`XState: Trigger Event "${eventKey}"`);
@@ -62,6 +63,17 @@ export function createCypressModel<
       };
     }
   });
-  return createModel<TTestContext, any>(machine).withEvents(cypressEventMap);
+  const result = createModel<TTestContext, any>(machine).withEvents(
+    cypressEventMap
+  ) as UpdateableCypressModel<TTestContext>;
+  result.update = <TNewTestContext = TTestContext>(
+    newTestMeta: any,
+    newTestEvents: any
+  ) =>
+    createCypressModel<TMachine, TNewTestContext>(
+      machine.update<TNewTestContext>(newTestMeta) as TMachine,
+      newTestEvents || eventMap
+    );
+  return result;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { TestModel } from '@xstate/test';
 import {
   AnyEventObject,
   EventObject,
@@ -34,10 +35,30 @@ export interface UpdatableCypressMachine<
    * @param testMeta
    * @param options
    */
-  update(
-    testMeta?: null | Record<string, TestMetaFunction<TTestContext>>,
+  update<TNewTestContext = TTestContext>(
+    testMeta?: null | Record<string, TestMetaFunction<TNewTestContext>>,
     options?: null | Partial<MachineOptions<TContext, TEvent | DoNothingEvent>>
-  ): StateMachine<TContext, any, TEvent | DoNothingEvent, TTypestate>;
+  ): UpdatableCypressMachine<TNewTestContext, TEvent, TContext, TTypestate>;
+}
+
+export interface UpdateableCypressModel<
+  TTestContext = Record<string, any>,
+  TEvent extends EventObject = AnyEventObject,
+  TContext = Record<never, never>,
+  TTypestate extends Typestate<TContext> = {
+    value: any;
+    context: TContext;
+  }
+> extends TestModel<TTestContext, TContext> {
+  /**
+   * Pass null if you want to clear the option completely, otherwise it will default to the original value. Note that values are not merged and all old values you don't want to change need to be passed
+   * @param testMeta
+   * @param eventMap
+   */
+  update<TNewTestContext = TTestContext>(
+    testMeta?: null | Record<string, TestMetaFunction<TNewTestContext>>,
+    eventMap?: CypressTestEventsConfig<TNewTestContext>
+  ): UpdateableCypressModel<TNewTestContext, TEvent, TContext, TTypestate>;
 }
 
 export interface EventCase {


### PR DESCRIPTION
Adding a new convenience function for reusing the same machine and rebinding the implementation details.

The test I added is a simplified version of my real use case where I wanted to reuse just one path of the machine and override a single event (with some variants).

Have chosen to not merge with previously passed events/test meta so the implementer can choose to override as needed.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.0--canary.7.5a671ec9f01a59e7b7f0a6988901106e6a149db7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install xstate-test-cypress@1.5.0--canary.7.5a671ec9f01a59e7b7f0a6988901106e6a149db7.0
  # or 
  yarn add xstate-test-cypress@1.5.0--canary.7.5a671ec9f01a59e7b7f0a6988901106e6a149db7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
